### PR TITLE
update build.yml : execute on PR too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - '!refs/tags/.*'
     tags-ignore:
       - '*'
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   linux-image:


### PR DESCRIPTION
Similar to what Wave and Nextflow do:
- https://github.com/seqeralabs/wave/blob/master/.github/workflows/build.yml
- https://github.com/nextflow-io/nextflow/blob/master/.github/workflows/build.yml

And to what I implemented yesterday for wave-cli and fusion.

What I had noticed is that PRs with single commit would not trigger the workflows, resulting for instance in skipped CI tests.
