### PR TITLE
bumped org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,15 @@
  *  defined by the Mozilla Public License, v. 2.0.
  */
 
+buildscript {
+    dependencies {
+        classpath('dev.yumi:yumi-gradle-licenser:2.2.2') {
+            exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
+        }
+        classpath 'org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r'
+    }
+}
+
 plugins {
     alias(libs.plugins.licenser)
     alias(libs.plugins.graalvmNative)


### PR DESCRIPTION
This PR solves https://github.com/seqeralabs/tower-agent/security/dependabot/41
```
tower-agent % ./gradlew buildEnvironment  | grep -A2 "org.eclipse.jgit"
|    +--- org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r -> 6.10.1.202505221210-r
|    |    +--- com.googlecode.javaewah:JavaEWAH:1.2.3
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
--
+--- org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r (*)
+--- dev.yumi.gradle.licenser:dev.yumi.gradle.licenser.gradle.plugin:2.2.2
|    \--- dev.yumi:yumi-gradle-licenser:2.2.2 (*)
```