### PR TITLE
chore(deps): bump graalvm-native, licenser, and shadow plugin versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-graalvmNativeVersion = "0.10.6"
+graalvmNativeVersion = "0.11.1"
 junitVersion = "5.14.3"
-licenserVersion = "2.2.2"
+licenserVersion = "3.0.1"
 micronautApplicationVersion = "4.6.2"
-shadowVersion = "9.3.1"
+shadowVersion = "9.4.1"
 
 [libraries]
 graalvmSvm = { group = "org.graalvm.nativeimage", name = "svm" }


### PR DESCRIPTION
## Summary

Relates to https://seqera.atlassian.net/browse/COMP-1400

- `org.graalvm.buildtools.native`: `0.10.6` → `0.11.1`
- `dev.yumi.gradle.licenser`: `2.2.2` → `3.0.1` (major bump — may require config changes)
- `com.gradleup.shadow`: `9.3.1` → `9.4.1`

## Test plan

- [x] Build passes locally
- [x] Native image compilation succeeds
- [x] License headers still applied correctly (licenser major bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)