### PR TITLE
fix(ci): update GitHub Actions to Node.js 24 compatible versions [COMP-1604]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew cleanTest test
 
       - name: Tests reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: linux-test-reports
@@ -52,13 +52,13 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Upload linux native image artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tw-agent-linux
           path: build/native/nativeCompile/tw-agent
 
       - name: Upload fat JAR artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tw-agent-jar
           path: build/libs/tw-agent.jar
@@ -74,12 +74,12 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Setup Java for JReleaser
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0

--- a/.github/workflows/security_submit_dependencies.yml
+++ b/.github/workflows/security_submit_dependencies.yml
@@ -11,7 +11,7 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Graalvm
       uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
       with:


### PR DESCRIPTION
## Summary

Closes COMP-1604

- Updates `actions/checkout` v4.3.1 → v6.0.2 (Node.js 24) in all workflows, including the very old v2.7.0 (Node.js 12) in the release job
- Updates `actions/upload-artifact` v4.6.2 → v7.0.1 (Node.js 24)
- Updates `actions/download-artifact` v4.3.0 → v8.0.1 (Node.js 24)

## Context
Node.js 20 actions are deprecated. GitHub will force Node.js 24 by default on June 2, 2026 and remove Node.js 20 from runners on September 16, 2026.

Fixes [COMP-1604](https://seqera.atlassian.net/browse/COMP-1604)

## Test plan
- [x] Verify the `Linux` CI job passes on this branch
- [x] Verify the `dependency-submission` job passes on master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-1604]: https://seqera.atlassian.net/browse/COMP-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ