### PR TITLE
chore(deps): bump GraalVM Native Build Tools plugin 0.11.1 → 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ java {
 }
 
 graalvmNative {
+    metadataRepository {
+        version = "0.3.35"
+    }
     binaries {
         main {
             imageName = 'tw-agent'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-graalvmNativeVersion = "0.11.1"
+graalvmNativeVersion = "1.1.0"
 junitVersion = "5.14.3"
 licenserVersion = "3.0.1"
 micronautApplicationVersion = "4.6.2"


### PR DESCRIPTION
## Summary

- Bumps `org.graalvm.buildtools.native` plugin from `0.11.1` to `1.1.0`
- Pins GraalVM reachability metadata repository to `0.3.35` for compatibility with GraalVM Community 21

## Background

Plugin 1.1.0 bundles reachability metadata repo 1.0.0, which uses a new `reachability-metadata.json` schema that requires GraalVM 25+. Since CI uses GraalVM Community 21 (and GraalVM 25 is not yet stable), the metadata repository is pinned to the latest `0.3.x` release (`0.3.35`), which skips the new schema validation. The pin can be removed once CI is upgraded to GraalVM 25.

No DSL changes were required — the existing `graalvmNative` block is fully compatible with 1.1.0.

## Test plan

- [ ] CI native image build passes
- [ ] Run `./gradlew listLibrariesMissingMetadata` to verify all dependencies have reachability metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)