### PR TITLE
chore(deps): bump graalvm-native to 0.11.5 and junit-bom to 5.14.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-graalvmNativeVersion = "0.11.1"
-junitVersion = "5.14.3"
+graalvmNativeVersion = "0.11.5"
+junitVersion = "5.14.4"
 licenserVersion = "4.0.0"
 micronautApplicationVersion = "4.6.2"
 shadowVersion = "9.4.1"


### PR DESCRIPTION
## Summary

- Bumps `org.graalvm.buildtools.native` from `0.11.1` to `0.11.5`
- Bumps `org.junit:junit-bom` from `5.14.3` to `5.14.4`

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)