### PR TITLE
fix(deps): upgrade micronautVersion to 4.10.14 (COMP-1762)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.11
+micronautVersion=4.10.14


### PR DESCRIPTION
## Summary
- Upgrades `micronautVersion` from `4.10.11` to `4.10.14` in `gradle.properties`
- This transitively upgrades `io.netty:netty-codec-http` and `io.netty:netty-codec-http2` from `4.2.12.Final` to `4.2.13.Final` (the patched version) via `micronaut-http-netty:4.10.23`
- Resolves CVE-2026-42587 / GHSA-f6hv-jmp6-3vwv

## JIRA
COMP-1762: Fix Netty: HttpContentDecompressor maxAllocation bypass when Content-Encoding set to br/zstd/snappy leads to decompression bomb DoS

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/61

🤖 Generated with [Claude Code](https://claude.ai/code)