### PR TITLE
fix(deps): upgrade micronaut platform to 4.10.16 to resolve CVE-2026-42587 (COMP-1763)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.11
+micronautVersion=4.10.16


### PR DESCRIPTION
## Summary
- Upgrades `micronautVersion` from `4.10.11` to `4.10.16` in `gradle.properties`
- The new Micronaut platform BOM ships `io.netty:netty-bom:4.2.15.Final`, upgrading `io.netty:netty-codec-http2` from `4.2.12.Final` to `4.2.15.Final`
- Resolves CVE-2026-42587 / GHSA-f6hv-jmp6-3vwv

## Root cause
`io.netty:netty-codec-http2` is a transitive dependency managed by the Micronaut platform BOM. The vulnerable range is `>= 4.2.0.Alpha1, <= 4.2.12.Final`. The fix is in `4.2.13.Final+`. Upgrading the Micronaut platform from `4.10.11` (which pins `netty 4.2.12.Final`) to `4.10.16` (which pins `netty 4.2.15.Final`) resolves the transitive vulnerability without adding any constraints or force-pins.

## JIRA
COMP-1763: Fix Netty: HttpContentDecompressor maxAllocation bypass when Content-Encoding set to br/zstd/snappy leads to decompression bomb DoS

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/62

🤖 Generated with [Claude Code](https://claude.ai/code)