### PR TITLE
fix(deps): upgrade micronaut-platform to 4.10.16 to resolve Netty CVE (COMP-1759)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.11
+micronautVersion=4.10.16


### PR DESCRIPTION
## Summary
- Upgrades `io.micronaut.platform:micronaut-platform` from `4.10.11` to `4.10.16`
- The new platform BOM brings in `micronaut-core-bom:4.10.25` which ships `io.netty:netty-bom:4.2.15.Final`
- Resolves CVE-2026-42583 / GHSA-mj4r-2hfc-f8p6 (Netty `Lz4FrameDecoder` resource exhaustion — patched in Netty >= 4.2.13.Final)

## JIRA
COMP-1759: Fix Netty Lz4FrameDecoder is vulnerable to resource exhaustion

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/58

🤖 Generated with [Claude Code](https://claude.ai/code)