### PR TITLE
fix(deps): upgrade Micronaut platform to 4.10.16 (COMP-1760)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ graalvmNative {
 }
 
 micronaut {
+    version "4.10.16"
     runtime("netty")
     testRuntime("junit5")
     processing {


### PR DESCRIPTION
## Summary
- Upgrades `io.micronaut:micronaut-context` from `4.10.20` to `4.10.25` by pinning the Micronaut platform version to `4.10.16` in the `micronaut {}` DSL block
- Resolves CVE-2026-44241 / GHSA-8hjv-92q9-g4xj: unbounded `formattersCache` in `TimeConverterRegistrar` allowing memory exhaustion via `Accept-Language` header
- The fix is applied by setting `version "4.10.16"` in the `micronaut {}` block, which upgrades the `io.micronaut.platform:micronaut-platform` BOM from `4.10.11` to `4.10.16`

## JIRA
COMP-1760: Fix Micronaut has unbounded `formattersCache` in `TimeConverterRegistrar` that Allows Memory Exhaustion via `Accept-Language` Header

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/54

🤖 Generated with [Claude Code](https://claude.ai/code)