### PR TITLE
fix(deps): upgrade micronautVersion to 4.10.16 (COMP-1758)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.11
+micronautVersion=4.10.16


### PR DESCRIPTION
## Summary
- Upgrades `micronautVersion` from `4.10.11` to `4.10.16` in `gradle.properties`
- This upgrades the Netty BOM (via Micronaut platform) from `4.2.12.Final` to `4.2.15.Final`
- Resolves CVE-2026-42584 / GHSA-57rv-r2g8-2cj3: HttpClientCodec response desynchronization in `io.netty:netty-codec-http`

## JIRA
COMP-1758: Fix Netty has HttpClientCodec response desynchronization

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/59

## Notes
`io.netty:netty-codec-http` is a transitive dependency managed by the Micronaut platform BOM.
Upgrading `micronautVersion` to `4.10.16` is the correct fix — it upgrades the platform BOM which
sets `netty.version=4.2.15.Final`, resolving the vulnerability without resorting to force-pins or
resolution strategies.

🤖 Generated with [Claude Code](https://claude.ai/code)