### PR TITLE
fix(deps): upgrade shadow plugin to 9.4.3 to resolve plexus-utils traversal (COMP-1572)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ graalvmNativeVersion = "0.11.5"
 junitVersion = "5.14.4"
 licenserVersion = "4.0.0"
 micronautApplicationVersion = "4.6.2"
-shadowVersion = "9.4.1"
+shadowVersion = "9.4.3"
 
 [libraries]
 graalvmSvm = { group = "org.graalvm.nativeimage", name = "svm" }


### PR DESCRIPTION
## Summary
- Bumps the `com.gradleup.shadow` Gradle plugin from `9.4.1` to `9.4.3`.
- Shadow `9.4.3` ships the patched `org.codehaus.plexus:plexus-utils` `4.0.3` (previously `4.0.2`), the transitive dependency affected by the vulnerability. Verified via `./gradlew buildEnvironment` — plexus-utils now resolves to `4.0.3`.
- `plexus-utils` is not declared directly in this repo; per policy it is fixed by upgrading the directly declared parent (the shadow plugin) rather than pinning the transitive dependency.
- Resolves CVE-2025-67030 / GHSA-6fmv-xxpf-w3cw (Directory Traversal in `org.codehaus.plexus.util.Expand.extractFile`).

## JIRA
COMP-1572: Fix Plexus-Utils has a Directory Traversal vulnerability in its extractFile method

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/48

🤖 Generated with [Claude Code](https://claude.ai/code)