### PR TITLE
fix(deps): pin Jackson to 2.21.5 to patch two high-severity PTV bypass CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 }
 
 dependencies {
+    // Lift Jackson to the patched release (CVE-2026-54512, CVE-2026-54513).
+    // The Micronaut BOM otherwise resolves a vulnerable jackson-databind below the 2.21.4
+    // fix. Drop this once the Micronaut BOM ships jackson >= 2.21.4.
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     annotationProcessor(libs.picocliCodegen)
     annotationProcessor(libs.micronautHttpValidation)
     annotationProcessor(libs.micronautInjectJava)


### PR DESCRIPTION
## Description

The Micronaut BOM resolves `jackson-databind` to `2.21.2` on the agent, which is vulnerable to two high-severity PolymorphicTypeValidator (PTV) allow-list bypasses. Both reach any path that deserializes untrusted JSON with a configured PTV and can lead to arbitrary class instantiation.

The 2.19–2.21 line is only fixed in `2.21.4`, and the 4.x Micronaut platform BOM does not yet ship a patched jackson, so a platform bump does not help. Importing the Jackson BOM at `2.21.5` lets Gradle's version conflict resolution lift every jackson module (`databind`, `core`, `annotations`) to the patched release. It stays inside the 2.21.x line, so it is a patch-level change. The pin can be removed once the Micronaut platform BOM ships jackson `>= 2.21.4`.

Fixes:
- **COMP-1991** / CVE-2026-54512 (GHSA-j3rv-43j4-c7qm): PTV bypass via generic type parameters allows arbitrary class instantiation.
- **COMP-1992** / CVE-2026-54513 (GHSA-rmj7-2vxq-3g9f): array subtype allow-list bypass in `BasicPolymorphicTypeValidator.allowIfSubTypeIsArray()`.

## Test plan

- `./gradlew dependencies --configuration runtimeClasspath` resolves `jackson-databind`, `jackson-core`, and `jackson-annotations` to `2.21.5` (every `2.21.2` node shows `-> 2.21.5`); no dependency fails to resolve.
- CI build and tests validate the full runtime.
