### PR TITLE
fix(deps): upgrade micronaut platform to 4.10.17 to resolve CVE-2026-56819 (COMP-2255)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.16
+micronautVersion=4.10.17


### PR DESCRIPTION
## Summary
- Upgrades `micronautVersion` from `4.10.16` to `4.10.17` in `gradle.properties`
- The 4.10.17 platform BOM ships `io.netty:netty-bom:4.2.16.Final` (4.10.16 shipped `4.2.15.Final`)
- Resolves CVE-2026-56819 / GHSA-93wv-jw9v-4972 in `io.netty:netty-codec-http2` (vulnerable range `>= 4.2.0, <= 4.2.15.Final`)

Netty is a transitive dependency of the Micronaut netty runtime (`micronaut { runtime("netty") }`), so the fix upgrades the declaring platform BOM rather than pinning netty directly. Same approach as #94 (COMP-1763).

## Vulnerability
`DelegatingDecompressorFrameListener.Http2Decompressor.decompress(...)` calls `decompressor.writeInbound(data.retain())`. If the decompressor's `EmbeddedChannel` is already closed, `ensureOpen()` throws before the buffer enters the pipeline, and the `catch (Throwable)` path never rolls back the extra `retain()`. A remote peer sending DATA frames for a removed stream leaks one direct `ByteBuf` per frame, exhausting direct memory (OOM DoS).

## Verification
```
$ ./gradlew dependencies --configuration runtimeClasspath | grep netty-codec-http2
+--- io.netty:netty-codec-http2:4.2.16.Final
```
`./gradlew build -x test` passes.

## JIRA
COMP-2255: Fix Netty: HTTP/2 decompression leaks ByteBuf reference count when the decompressor channel is already closed (Direct memory leak / OOM DoS)

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/82

🤖 Generated with [Claude Code](https://claude.com/claude-code)