### PR TITLE
fix(deps): upgrade Micronaut platform to 4.10.17 (COMP-2248)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.16
+micronautVersion=4.10.17


### PR DESCRIPTION
## Summary
- Bumps `micronautVersion` from `4.10.16` to `4.10.17` in `gradle.properties`.
- The Micronaut platform BOM is what supplies netty here (netty is not declared directly). Platform `4.10.16` pins `netty.version=4.2.15.Final`; platform `4.10.17` pins `netty.version=4.2.16.Final`, the patched release. No constraint or force-pin is used.
- Resolves CVE-2026-56745 / GHSA-jppx-w49h-x2qq (`io.netty:netty-codec-http`, vulnerable range `>= 4.2.0.Final, <= 4.2.15.Final`).

## Verification
- `./gradlew dependencies --configuration runtimeClasspath` — every `io.netty:*` artifact now resolves to `4.2.16.Final` (was `4.2.15.Final`).
- `./gradlew build` — BUILD SUCCESSFUL (compile, license checks, tests).

## JIRA
[COMP-2248](https://seqera.atlassian.net/browse/COMP-2248): Fix Netty: [SpdyHttpDecoder] ByteBuf Reference Leak on RST_STREAM Leads to Native Memory Exhaustion

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-2248]: https://seqera.atlassian.net/browse/COMP-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ