### PR TITLE
fix(deps): upgrade Micronaut platform BOM to 4.10.17 (COMP-2252)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,10 @@ graalvmNative {
 }
 
 micronaut {
+    // The plugin's default Micronaut platform BOM (4.10.16) resolves netty 4.2.15.Final,
+    // which is vulnerable to CVE-2026-59901. Pinning the BOM lifts netty to 4.2.16.Final.
+    // Drop this once the io.micronaut.application plugin defaults to 4.10.17 or later.
+    version(libs.versions.micronautPlatformVersion.get())
     runtime("netty")
     testRuntime("junit5")
     processing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ graalvmNativeVersion = "0.11.5"
 junitVersion = "5.14.4"
 licenserVersion = "4.0.0"
 micronautApplicationVersion = "4.6.2"
+micronautPlatformVersion = "4.10.17"
 shadowVersion = "9.4.3"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Netty is **transitive** in `tower-agent`, introduced by the Micronaut platform BOM that the `io.micronaut.application` plugin (4.6.2) defaults to (`io.micronaut.platform:micronaut-platform:4.10.16` → `io.netty:netty-codec-compression:4.2.15.Final`).
- Declares the Micronaut platform version explicitly as `4.10.17` (which ships `netty 4.2.16.Final`) via the plugin's own `micronaut { version(...) }` DSL — no `resolutionStrategy.force` or dependency constraint on the transitive artifact.
- Verified: `./gradlew dependencies --configuration runtimeClasspath` now resolves `io.netty:netty-codec-compression:4.2.16.Final`; `./gradlew build` passes.

## JIRA
COMP-2252: Fix Netty: [Bzip2Decoder] Infinite Loop in RLE State Machine Leads to Event-Loop Thread Hang

## Security Advisory
CVE-2026-59901 / GHSA-558v-64gr-wgg4
https://github.com/seqeralabs/tower-agent/security/dependabot/80

🤖 Generated with [Claude Code](https://claude.ai/code)