### PR TITLE
fix(deps): upgrade Micronaut to 4.10.17 for netty 4.2.16.Final (COMP-2246)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.16
+micronautVersion=4.10.17


### PR DESCRIPTION
## Summary
- Bumps `micronautVersion` in `gradle.properties` from `4.10.16` to `4.10.17`.
- The Micronaut platform BOM is what pins `io.netty:netty-codec-http`; `4.10.16` resolved `4.2.15.Final` (vulnerable range `>= 4.2.0.Final, <= 4.2.15.Final`). Micronaut `4.10.17` sets `netty.version` to `4.2.16.Final`, the patched release.
- Resolves CVE-2026-55831 / GHSA-6jqx-86gh-f27w (Netty SPDY SETTINGS frame count materializes an unbounded settings map — remote DoS, CVSS 7.5).

No force-pin or dependency constraint was added; the declaring dependency was upgraded instead.

## Verification
- `./gradlew dependencies --configuration runtimeClasspath | grep netty-codec-http` → `io.netty:netty-codec-http:4.2.16.Final`
- `./gradlew build` passes.

## JIRA
[COMP-2246](https://seqera.atlassian.net/browse/COMP-2246): Fix Netty SPDY SETTINGS frame count materializes unbounded settings map

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-2246]: https://seqera.atlassian.net/browse/COMP-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ