### PR TITLE
fix(deps): upgrade Micronaut to 4.10.17 to pull netty 4.2.16.Final (COMP-2247)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.16
+micronautVersion=4.10.17


### PR DESCRIPTION
## Summary
- `io.netty:netty-codec-http` resolved to `4.2.15.Final` (vulnerable range `>= 4.2.0.Final, <= 4.2.15.Final`) as a transitive dependency of the Micronaut platform BOM.
- Bumps `micronautVersion` `4.10.16` → `4.10.17` in `gradle.properties`. That release ships `micronaut-core-bom` `4.10.26`, which pins `netty.version=4.2.16.Final`.
- No force/constraint/override pin was added — the fix comes from upgrading the directly declared BOM.
- Resolves CVE-2026-55833 / GHSA-mvh2-crg5-v77c.

## Verification
- `./gradlew dependencyInsight --configuration runtimeClasspath --dependency io.netty` — every `io.netty:*` artifact now resolves to `4.2.16.Final`.
- `./gradlew build` — BUILD SUCCESSFUL (compile, licence check, tests).

## JIRA
COMP-2247: Fix Netty SPDY zlib header block continues decoded expansion after maxHeaderSize truncation

## Security Advisory
https://github.com/seqeralabs/tower-agent/security/dependabot/74

🤖 Generated with [Claude Code](https://claude.com/claude-code)